### PR TITLE
Improve error output for invalid BIOSes

### DIFF
--- a/builder/builder.cc
+++ b/builder/builder.cc
@@ -253,9 +253,10 @@ int main(int argc, char** argv) {
             }
         }
         if (!found) {
-            printf("Unsupported BIOS %02x. Supported BIOS are:\n", biosVersion);
+            printf("Unsupported BIOS %x.%x. Supported BIOS are:\n", biosVersion >> 4, biosVersion & 0xF);
             for (const auto& it : biosExploitSettings) {
-                printf("%02x ", it.first.first);
+                const auto& curVersion = it.first.first;
+                printf("%x.%x ", curVersion >> 4, curVersion & 0xF);
             }
             printf("\n");
             return -1;


### PR DESCRIPTION
Super minor change that I wanted to add to the previous PR but you were faster than me haha. This modifies the output on error to output the version in the same format as it expects for input in the -bios parameter.

Instead of:
```
Unsupported BIOS 11. Supported BIOS are:
30 30 41 44 45
```
This logs errors as:
```
Unsupported BIOS 1.1. Supported BIOS are:
3.0 3.0 4.1 4.4 4.5
```