### PR TITLE
Minor improvements

### DIFF
--- a/builder/.gitignore
+++ b/builder/.gitignore
@@ -1,0 +1,4 @@
+*.mcd
+*.mcr
+*.exe
+builder

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -1,2 +1,4 @@
-all:
+all: builder
+
+builder: builder.cc
 	$(CXX) -o builder builder.cc -std=c++17

--- a/builder/builder.cc
+++ b/builder/builder.cc
@@ -379,7 +379,7 @@ int main(int argc, char** argv) {
     std::vector<uint32_t> disableInterrupts = {
         // disabling all interrupts except for memory card
         addiu(Reg::V0, Reg::R0, 128),
-        lui(Reg::V1, 0x1f00),
+        lui(Reg::V1, 0x1f80),
         sw(Reg::V0, 0x1074, Reg::V1),
     };
 


### PR DESCRIPTION
This PR:
 - Improves the Makefile for the builder so that "all" only builds if builder.cc has been changed (really useful if [using FreePSXBoot as a Git/Make submodule](https://raw.githubusercontent.com/socram8888/tonyhax/master/freepsxboot/Makefile), so that memory card images aren't continuosly being built.
 - Adds a gitignore for the builder folder, so the resulting binary isn't picked as a new file, nor created memory card files
 - Fixes the "disableInterrupts" payload which was writing to 0x1F**0**01074 instead to the correct 0x1F**8**01074.