### PR TITLE
Fix compiling on Fedora Linux

### DIFF
--- a/builder/builder.cc
+++ b/builder/builder.cc
@@ -19,6 +19,7 @@
 #include "stage2/common/util/encoder.hh"
 
 #include <iostream>
+#include <cstring>
 
 using namespace Mips::Encoder;
 


### PR DESCRIPTION
Fixes this error:

g++ -o builder builder.cc -std=c++17 -I.
builder.cc: In function ‘void createImage(ImageSettings, const uint8_t*, uint32_t)’:
builder.cc:693:14: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’?
  693 |         std::memcpy(out.data() + out.size() / 2, out.data(), out.size() / 2);
      |              ^~~~~~
      |              wmemcpy
make[2]: *** [Makefile:4: builder] Error 1

When compiling on Fedora Linux 36 using standard g++ from dnf. Output of Fedora's g++ with the -v argument is below:

Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/12/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,objc,obj-c++,ada,go,d,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --enable-libstdcxx-backtrace --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl=/builddir/build/BUILD/gcc-12.2.1-20220819/obj-x86_64-redhat-linux/isl-install --enable-offload-targets=nvptx-none --without-cuda-driver --enable-offload-defaulted --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux --with-build-config=bootstrap-lto --enable-link-serialization=1
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.2.1 20220819 (Red Hat 12.2.1-1) (GCC)