### PR TITLE
Change injection point for bios 2.0 slot 1 so that a card isn't required to be present in slot 2

### DIFF
--- a/builder/builder.cc
+++ b/builder/builder.cc
@@ -101,9 +101,9 @@ static std::map<BIOSKey, ExploitSettings> slot1ExploitSettings{
      {0x801ffcc0, 0x80204d6c, 0x10000004, 0x10001c36, true, 3, 0, ExploitType::MemcardISR, -0x70cc}},
 
     {{20, 19950507, 'A', 0x55847d8c},
-     {0x801ffcc0, 0x80204ef4, 0x0c001ab0, 0x0c002f92, true, 2, 0, ExploitType::ICacheFlush}},
+     {0x801ffcc0, 0x80206a38, 0x24090025, 0x24091cd0, false, 3, 0}},
     {{20, 19950510, 'E', 0x9bb87c4b},
-     {0x801ffcb8, 0x80204ef4, 0x0c001ab0, 0x0c002f92, true, 3, 0, ExploitType::ICacheFlush}},
+     {0x801ffcb8, 0x80206aa8, 0x24090017, 0x24091cd0, false, 3, 0}},
 
     {{21, 19950717, 'A', 0xaff00f2f}, {0x801ffcc8, 0x80204de8, 0x1000003d, 0x10001c17, true}},
     {{21, 19950717, 'E', 0x86c30531}, {0x801ffcc0, 0x80204f64, 0x0c001acc, 0x0c002f92, true, 2, 8}},


### PR DESCRIPTION
This changes the corruption point for bios 2.0 for SCPH-1001 and SCPH-1002.

# Bios 55847d8c

![image](https://user-images.githubusercontent.com/1065521/214990201-b08bc532-bcc2-44fa-9e34-513c4226923e.png)

Now it's corrupting the argument $t1 in the "toupper" function at address 0x6A38. It is changed from 0x25 to 0x1cd0 so that the calculated address for the function pointer through the 0xA0 table is = 0x200 + 0x1cd0 * 4 = 0x7540. It just so happens that the `card_read` function stores the buffer pointer (i.e. 0xA000BE48) at that location.

With this implementation, the first "next" field is 0x1B5E, and the second "next" field is read from address 0x80042650, that stores value "01 00" and so the exploit should be 100% reliable:

![image](https://user-images.githubusercontent.com/1065521/214991400-e751f25a-d21f-497a-8a62-503fa4850bdd.png)

# Bios 9bb87c4b

![image](https://user-images.githubusercontent.com/1065521/214991498-12f821de-0e79-4a23-b8bd-6e18faa2b661.png)

Similar idea, but now injecting at 0x6AA8 in "strcmp". "next" is pointing to 0x800429d0 which stores "08 00":

![image](https://user-images.githubusercontent.com/1065521/214991617-11cfe101-7720-4c55-9022-3ec9f913f717.png)

# Testing

I've tested both on pcsx-redux patched to memset() ram with 0x80 rather than default zeroed out. I've tried both with just card 1 inserted and with both cards inserted, and it's successful every time. However I've not tested on actual hardware yet.